### PR TITLE
Fix mobile layout, favicon, and hero section positioning

### DIFF
--- a/client/components/layout/SiteHeader.tsx
+++ b/client/components/layout/SiteHeader.tsx
@@ -37,9 +37,12 @@ export default function SiteHeader() {
         <div className="flex items-center gap-3">
           <Link to="/" className="flex items-center gap-2">
             <img
-              src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fcb13d8bd4dd54d4c9b3a6b34a08291d1?format=webp&width=160"
+              src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fcb13d8bd4dd54d4c9b3a6b34a08291d1?format=webp&width=320"
+              srcSet="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fcb13d8bd4dd54d4c9b3a6b34a08291d1?format=webp&width=320 1x, https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fcb13d8bd4dd54d4c9b3a6b34a08291d1?format=webp&width=640 2x"
               alt="Clarra"
               className="h-20 w-auto md:h-24 bg-transparent"
+              loading="eager"
+              decoding="async"
             />
           </Link>
         </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,7 +103,7 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:-translate-x-[100%] relative">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:translate-x-[65%] relative">
               <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,14 +103,23 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[25%]">
-              <img
-                src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
-                alt="Chat with Clarra phone mockup"
-                className="w-full max-w-xs sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl scale-[1.5] sm:scale-[1.7] origin-center mx-auto"
-                loading="eager"
-                decoding="async"
-              />
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[75%] relative">
+              <div className="relative inline-block">
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
+                  alt="Chat with Clarra phone mockup"
+                  className="relative z-10 w-full max-w-xs sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl scale-[1.5] sm:scale-[1.7] origin-center mx-auto"
+                  loading="eager"
+                  decoding="async"
+                />
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
+                  alt=""
+                  aria-hidden="true"
+                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-[160%] max-w-none opacity-95"
+                  decoding="async"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -60,9 +60,9 @@ export default function Index() {
       <section className="py-8">
         <div className="container">
           <div className="grid items-center gap-8 sm:grid-cols-2">
-            <div className="sm:order-1 transform sm:translate-x-[10%]">
-              <h3 className="mb-4 text-3xl font-semibold text-foreground/90">
-                Clarra features
+            <div className="order-2 sm:order-1 sm:translate-x-[10%]">
+              <h3 className="mb-8 text-3xl font-semibold text-foreground/90">
+                Clarra Features
               </h3>
               <ul className="space-y-4">
                 <li className="flex items-start gap-3">
@@ -103,11 +103,11 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="sm:order-2 flex justify-center sm:justify-end transform sm:-translate-x-[25%]">
+            <div className="order-1 sm:order-2 flex justify-center sm:justify-end sm:-translate-x-[25%]">
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
                 alt="Chat with Clarra phone mockup"
-                className="w-full max-w-xs sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl transform scale-[1.7]"
+                className="w-full max-w-xs sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl scale-100 sm:scale-[1.7] mx-auto"
                 loading="eager"
                 decoding="async"
               />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,11 +103,11 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center sm:justify-end sm:-translate-x-[25%]">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[25%]">
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
                 alt="Chat with Clarra phone mockup"
-                className="w-full max-w-xs sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl scale-100 sm:scale-[1.7] mx-auto"
+                className="w-full max-w-xs sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl scale-[1.5] sm:scale-[1.7] origin-center mx-auto"
                 loading="eager"
                 decoding="async"
               />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,8 +103,8 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[75%] relative">
-              <div className="relative inline-block">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[25%] relative">
+              <div className="relative inline-block sm:-translate-y-[10%]">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
                   alt="Chat with Clarra phone mockup"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -57,7 +57,7 @@ export default function Index() {
       </section>
 
       {/* Hero split: features left, image right */}
-      <section className="py-8">
+      <section className="py-8 pt-16 sm:pt-8">
         <div className="container">
           <div className="grid items-center gap-8 sm:grid-cols-2">
             <div className="order-2 sm:order-1 sm:translate-x-[10%]">
@@ -103,7 +103,7 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:translate-x-0 relative">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:-translate-x-[100%] relative">
               <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
@@ -116,7 +116,7 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-[160%] max-w-none opacity-95 sm:hidden"
+                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-[160%] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,7 +103,7 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:translate-x-[65%] relative">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-center -translate-x-[25%] sm:translate-x-[65%] relative overflow-visible">
               <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,7 +103,7 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-center -translate-x-[25%] sm:translate-x-[65%] relative overflow-visible">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:translate-x-0 relative overflow-visible">
               <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,7 +103,7 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:translate-x-0 relative overflow-visible">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:-translate-x-[30%] relative overflow-visible">
               <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,8 +103,8 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[25%] relative">
-              <div className="relative inline-block sm:-translate-y-[10%]">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:translate-x-0 relative">
+              <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
                   alt="Chat with Clarra phone mockup"
@@ -116,7 +116,7 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-[160%] max-w-none opacity-95"
+                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-[160%] max-w-none opacity-95 sm:hidden"
                   decoding="async"
                 />
               </div>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,11 @@
       content="Clarra is an AI-native digital health app for midlife care, offering compassionate, personalized support for perimenopause and menopause."
     />
     <meta name="theme-color" content="#4fb7b3" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" type="image/png" sizes="32x32" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32" />
+    <link rel="icon" type="image/png" sizes="48x48" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=48" />
+    <link rel="icon" type="image/png" sizes="192x192" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=192" />
+    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=180" />
+    <link rel="shortcut icon" type="image/png" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32" />
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,34 @@
       content="Clarra is an AI-native digital health app for midlife care, offering compassionate, personalized support for perimenopause and menopause."
     />
     <meta name="theme-color" content="#4fb7b3" />
-    <link rel="icon" type="image/png" sizes="32x32" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32" />
-    <link rel="icon" type="image/png" sizes="48x48" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=48" />
-    <link rel="icon" type="image/png" sizes="192x192" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=192" />
-    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=180" />
-    <link rel="shortcut icon" type="image/png" href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="48x48"
+      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=48"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=192"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=180"
+    />
+    <link
+      rel="shortcut icon"
+      type="image/png"
+      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32"
+    />
   </head>
 
   <body>


### PR DESCRIPTION
## Purpose

The user requested comprehensive mobile-specific layout improvements including:
- Moving and centering the hero image above text on mobile only
- Fixing blurry navigation logo and favicon distortion
- Adjusting image positioning and sizing for better mobile experience
- Adding background image behind the hero image on mobile
- Ensuring desktop layout remains unchanged while optimizing mobile view

## Code changes

- **Favicon updates**: Replaced distorted SVG favicon with high-quality PNG versions in multiple sizes (32x32, 48x48, 192x192, 180x180) for better cross-device compatibility
- **Navigation logo**: Enhanced logo image with higher resolution (320px width) and added srcSet for retina displays, plus eager loading attributes
- **Hero section layout**: 
  - Moved "Clarra Features" title up with increased margin (mb-8) and capitalized "Features"
  - Reordered mobile layout to show image above text (order-1/order-2 classes)
  - Added mobile-specific background image positioned behind the hero image
  - Adjusted image positioning with responsive transforms and scaling
  - Added mobile-only background image that doesn't interfere with buttons
- **Mobile-specific styling**: Used responsive classes to ensure changes only apply to mobile while preserving desktop layoutTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/aura-home)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-aura-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>aura-home</branchName>-->