### PR TITLE
Add larger favicon sizes and SVG support

### DIFF
--- a/client/components/layout/Layout.tsx
+++ b/client/components/layout/Layout.tsx
@@ -6,7 +6,10 @@ import SiteFooter from "./SiteFooter";
 function ScrollToTop() {
   const { pathname } = useLocation();
   useEffect(() => {
-    if (typeof window !== "undefined" && "scrollRestoration" in window.history) {
+    if (
+      typeof window !== "undefined" &&
+      "scrollRestoration" in window.history
+    ) {
       try {
         window.history.scrollRestoration = "manual";
       } catch {}

--- a/client/components/layout/Layout.tsx
+++ b/client/components/layout/Layout.tsx
@@ -6,7 +6,20 @@ import SiteFooter from "./SiteFooter";
 function ScrollToTop() {
   const { pathname } = useLocation();
   useEffect(() => {
-    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    if (typeof window !== "undefined" && "scrollRestoration" in window.history) {
+      try {
+        window.history.scrollRestoration = "manual";
+      } catch {}
+    }
+    const scrollTop = () => {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+      // Fallbacks for iOS Safari
+      document.documentElement.scrollTop = 0;
+      document.body.scrollTop = 0;
+    };
+    // Next frame to ensure route content has rendered
+    requestAnimationFrame(scrollTop);
+    setTimeout(scrollTop, 0);
   }, [pathname]);
   return null;
 }

--- a/client/global.css
+++ b/client/global.css
@@ -99,14 +99,18 @@
     @apply border-border;
   }
 
-  html, body {
+  html,
+  body {
     @apply bg-background text-foreground font-sans;
     max-width: 100%;
     overflow-x: hidden;
   }
 
   /* Ensure media never causes horizontal overflow */
-  img, video, canvas, svg {
+  img,
+  video,
+  canvas,
+  svg {
     max-width: 100%;
     height: auto;
     display: block;

--- a/client/global.css
+++ b/client/global.css
@@ -99,8 +99,17 @@
     @apply border-border;
   }
 
-  body {
+  html, body {
     @apply bg-background text-foreground font-sans;
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  /* Ensure media never causes horizontal overflow */
+  img, video, canvas, svg {
+    max-width: 100%;
+    height: auto;
+    display: block;
   }
 
   .font-display {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       content="Clarra is an AI-native digital health app for midlife care, offering compassionate, personalized support for perimenopause and menopause."
     />
     <meta name="theme-color" content="#4fb7b3" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
     <link
       rel="icon"
       type="image/png"
@@ -28,14 +29,15 @@
       href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=192"
     />
     <link
+      rel="icon"
+      type="image/png"
+      sizes="512x512"
+      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=512"
+    />
+    <link
       rel="apple-touch-icon"
       sizes="180x180"
       href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=180"
-    />
-    <link
-      rel="shortcut icon"
-      type="image/png"
-      href="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fd361d3393e074edeb3ae4bdb02c9f57a?format=png&width=32"
     />
   </head>
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <!-- Solid white background to avoid transparency/cutouts -->
-  <rect width="512" height="512" fill="#ffffff"/>
-  <!-- Logo mark -->
-  <circle cx="256" cy="348" r="164" fill="#4fb7b3"/>
-  <circle cx="164" cy="236" r="140" fill="#b9e3e2"/>
-  <circle cx="348" cy="236" r="140" fill="#b9e3e2"/>
-  <circle cx="256" cy="156" r="120" fill="#56d257"/>
+  <!-- Tighten graphic to fill the square and keep transparency -->
+  <g transform="translate(6.35 0) scale(1.076) translate(-24 -36)">
+    <circle cx="256" cy="348" r="164" fill="#4fb7b3"/>
+    <circle cx="164" cy="236" r="140" fill="#b9e3e2"/>
+    <circle cx="348" cy="236" r="140" fill="#b9e3e2"/>
+    <circle cx="256" cy="156" r="120" fill="#56d257"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Purpose
The user requested to make the favicon as large as possible without distorting it to improve browser display and visibility.

## Code changes
- Added SVG favicon with `sizes="any"` for scalable vector support
- Added 512x512 PNG favicon for high-resolution displays
- Removed the 32px shortcut icon in favor of larger sizes
- Maintained existing 192x192 and 180x180 (Apple touch) icon sizes

These changes provide better favicon quality across different devices and screen resolutions while maximizing the favicon size as requested.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/quantum-forge)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-quantum-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>quantum-forge</branchName>-->