### PR TITLE
Fix mobile background image cutoff on right edge

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -103,7 +103,7 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end -translate-x-[25%] sm:-translate-x-[30%] relative overflow-visible">
+            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end translate-x-0 sm:-translate-x-[30%] relative overflow-visible">
               <div className="relative inline-block -translate-y-[10%] sm:translate-y-0">
                 <img
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -116,7 +116,7 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-[160%] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-6 left-1/2 -translate-x-1/2 w-screen max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                 />
               </div>


### PR DESCRIPTION
## Purpose
Fix mobile layout issue where the background image was being cut off on the right side. The user requested that the background image extend all the way to the edge on mobile devices.

## Code changes
- Removed horizontal translation (`-translate-x-[25%]`) on mobile for the main container, setting it to `translate-x-0` to center the content properly
- Changed background image width from `w-[160%]` to `w-screen` to ensure it spans the full viewport width on mobile devices
- Maintained existing desktop styling with `sm:-translate-x-[30%]` for larger screensTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/aura-zone)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-aura-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>aura-zone</branchName>-->