### PR TITLE
Fix mobile background image bleeding into Clarra features

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,7 +117,7 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-24 left-1/2 -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-32 left-1/2 -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                 />
               </div>


### PR DESCRIPTION
## Purpose
Fix visual issue on mobile where the green line background image was bleeding into the "Clarra features" section. The adjustment needed to be minimal to avoid impacting the "Our Tech" section positioning.

## Code changes
- Adjusted background image positioning from `-bottom-24` to `-bottom-32` in the mobile-specific className
- This moves the background image down by 8 units (32px) to prevent overlap with the Clarra features section
- Change only affects mobile view (`sm:hidden` class ensures desktop remains unchanged)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/curry-studio)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-curry-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>curry-studio</branchName>-->