### PR TITLE
Fix mobile background image positioning and z-index

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -114,18 +114,16 @@ export default function Index() {
                   decoding="async"
                 />
                 <img
-                  src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
+                  src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fbf45102ca2434602812f7c04a6ec255a?format=webp&width=800"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-[28rem] left-[36%] -translate-x-1/2 w-[130vw] max-w-none opacity-90 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-[32rem] left-1/2 -translate-x-1/2 w-[150vw] max-w-none opacity-90 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 4%, rgba(0,0,0,1) 12%)",
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 6%, rgba(0,0,0,0.85) 12%, rgba(0,0,0,1) 18%)",
                     maskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 4%, rgba(0,0,0,1) 12%)",
-                    WebkitMaskRepeat: "no-repeat",
-                    maskRepeat: "no-repeat",
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 6%, rgba(0,0,0,0.85) 12%, rgba(0,0,0,1) 18%)",
                   }}
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,16 +117,8 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-56 left-[62%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-64 left-[52%] -translate-x-1/2 w-[140vw] max-w-none opacity-80 sm:hidden -z-10"
                   decoding="async"
-                  style={{
-                    WebkitMaskImage:
-                      "radial-gradient(340px_220px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 82%, rgba(0,0,0,1) 96%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.35) 18%, rgba(0,0,0,1) 28%)",
-                    maskImage:
-                      "radial-gradient(340px_220px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 82%, rgba(0,0,0,1) 96%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.35) 18%, rgba(0,0,0,1) 28%)",
-                    WebkitMaskRepeat: "no-repeat",
-                    maskRepeat: "no-repeat",
-                  }}
                 />
               </div>
             </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,13 +117,13 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-48 left-[61%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-56 left-[62%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "radial-gradient(260px_180px_at_22%_90%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 80%, rgba(0,0,0,1) 95%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 14%, rgba(0,0,0,1) 22%)",
+                      "radial-gradient(340px_220px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 82%, rgba(0,0,0,1) 96%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.35) 18%, rgba(0,0,0,1) 28%)",
                     maskImage:
-                      "radial-gradient(260px_180px_at_22%_90%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 80%, rgba(0,0,0,1) 95%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 14%, rgba(0,0,0,1) 22%)",
+                      "radial-gradient(340px_220px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 82%, rgba(0,0,0,1) 96%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.35) 18%, rgba(0,0,0,1) 28%)",
                     WebkitMaskRepeat: "no-repeat",
                     maskRepeat: "no-repeat",
                   }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -62,7 +62,7 @@ export default function Index() {
         <div className="container">
           <div className="grid items-center gap-8 sm:grid-cols-2">
             <div className="order-2 sm:order-1 sm:translate-x-[10%]">
-              <h3 className="relative z-20 mb-8 text-3xl font-semibold text-foreground/90">
+              <h3 className="relative z-30 mb-8 text-3xl font-semibold text-foreground/90">
                 Clarra Features
               </h3>
               <ul className="space-y-4">
@@ -117,13 +117,13 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-36 left-[58%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-40 left-[60%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "radial-gradient(180px_140px_at_14%_78%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 60%, rgba(0,0,0,1) 82%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 10%, rgba(0,0,0,1) 18%)",
+                      "radial-gradient(220px_160px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 12%, rgba(0,0,0,1) 20%)",
                     maskImage:
-                      "radial-gradient(180px_140px_at_14%_78%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 60%, rgba(0,0,0,1) 82%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 10%, rgba(0,0,0,1) 18%)",
+                      "radial-gradient(220px_160px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 12%, rgba(0,0,0,1) 20%)",
                     WebkitMaskRepeat: "no-repeat",
                     maskRepeat: "no-repeat",
                   }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,8 +117,14 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-64 left-[52%] -translate-x-1/2 w-[140vw] max-w-none opacity-80 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-56 left-[46%] -translate-x-1/2 w-[140vw] max-w-none opacity-90 sm:hidden -z-10"
                   decoding="async"
+                  style={{
+                    WebkitMaskImage:
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 8%, rgba(0,0,0,0.85) 16%, rgba(0,0,0,1) 24%)",
+                    maskImage:
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 8%, rgba(0,0,0,0.85) 16%, rgba(0,0,0,1) 24%)",
+                  }}
                 />
               </div>
             </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -62,7 +62,7 @@ export default function Index() {
         <div className="container">
           <div className="grid items-center gap-8 sm:grid-cols-2">
             <div className="order-2 sm:order-1 sm:translate-x-[10%]">
-              <h3 className="mb-8 text-3xl font-semibold text-foreground/90">
+              <h3 className="relative z-20 mb-8 text-3xl font-semibold text-foreground/90">
                 Clarra Features
               </h3>
               <ul className="space-y-4">
@@ -117,13 +117,15 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-32 left-[54%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-36 left-[58%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 18%, rgba(0,0,0,1) 100%)",
+                      "radial-gradient(180px_140px_at_14%_78%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 60%, rgba(0,0,0,1) 82%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 10%, rgba(0,0,0,1) 18%)",
                     maskImage:
-                      "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 18%, rgba(0,0,0,1) 100%)",
+                      "radial-gradient(180px_140px_at_14%_78%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 60%, rgba(0,0,0,1) 82%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.55) 10%, rgba(0,0,0,1) 18%)",
+                    WebkitMaskRepeat: "no-repeat",
+                    maskRepeat: "no-repeat",
                   }}
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,15 +117,15 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-80 left-[40%] -translate-x-1/2 w-[140vw] max-w-none opacity-90 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-[28rem] left-[36%] -translate-x-1/2 w-[130vw] max-w-none opacity-90 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 6%, rgba(0,0,0,1) 14%), radial-gradient(360px_220px_at 12% 86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 95%)",
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 4%, rgba(0,0,0,1) 12%)",
                     maskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 6%, rgba(0,0,0,1) 14%), radial-gradient(360px_220px_at 12% 86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 95%)",
-                    WebkitMaskComposite: "destination-in",
-                    maskComposite: "intersect",
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 4%, rgba(0,0,0,1) 12%)",
+                    WebkitMaskRepeat: "no-repeat",
+                    maskRepeat: "no-repeat",
                   }}
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,13 +117,15 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-56 left-[46%] -translate-x-1/2 w-[140vw] max-w-none opacity-90 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-72 left-[68%] -translate-x-1/2 w-[140vw] max-w-none opacity-90 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 8%, rgba(0,0,0,0.85) 16%, rgba(0,0,0,1) 24%)",
+                      "radial-gradient(320px_180px_at 6% 18%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 70%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 15%, rgba(0,0,0,1) 28%), linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 24%)",
                     maskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 8%, rgba(0,0,0,0.85) 16%, rgba(0,0,0,1) 24%)",
+                      "radial-gradient(320px_180px_at 6% 18%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 70%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 15%, rgba(0,0,0,1) 28%), linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 24%)",
+                    WebkitMaskRepeat: "no-repeat",
+                    maskRepeat: "no-repeat",
                   }}
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,13 +117,13 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fbf45102ca2434602812f7c04a6ec255a?format=webp&width=800"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-[32rem] left-1/2 -translate-x-1/2 w-[150vw] max-w-none opacity-90 sm:hidden -z-10"
+                  className="pointer-events-none absolute bottom-0 left-[60%] -translate-x-1/2 w-[120vw] max-w-none opacity-90 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 6%, rgba(0,0,0,0.85) 12%, rgba(0,0,0,1) 18%)",
+                      "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 18%)",
                     maskImage:
-                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.2) 6%, rgba(0,0,0,0.85) 12%, rgba(0,0,0,1) 18%)",
+                      "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 18%)",
                   }}
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,13 +117,13 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-40 left-[60%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-48 left-[61%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "radial-gradient(220px_160px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 12%, rgba(0,0,0,1) 20%)",
+                      "radial-gradient(260px_180px_at_22%_90%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 80%, rgba(0,0,0,1) 95%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 14%, rgba(0,0,0,1) 22%)",
                     maskImage:
-                      "radial-gradient(220px_160px_at_18%_86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 12%, rgba(0,0,0,1) 20%)",
+                      "radial-gradient(260px_180px_at_22%_90%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 80%, rgba(0,0,0,1) 95%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.4) 14%, rgba(0,0,0,1) 22%)",
                     WebkitMaskRepeat: "no-repeat",
                     maskRepeat: "no-repeat",
                   }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,15 +117,15 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-72 left-[68%] -translate-x-1/2 w-[140vw] max-w-none opacity-90 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-80 left-[40%] -translate-x-1/2 w-[140vw] max-w-none opacity-90 sm:hidden -z-10"
                   decoding="async"
                   style={{
                     WebkitMaskImage:
-                      "radial-gradient(320px_180px_at 6% 18%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 70%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 15%, rgba(0,0,0,1) 28%), linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 24%)",
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 6%, rgba(0,0,0,1) 14%), radial-gradient(360px_220px_at 12% 86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 95%)",
                     maskImage:
-                      "radial-gradient(320px_180px_at 6% 18%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 70%, rgba(0,0,0,1) 92%), linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.45) 15%, rgba(0,0,0,1) 28%), linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 24%)",
-                    WebkitMaskRepeat: "no-repeat",
-                    maskRepeat: "no-repeat",
+                      "linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.5) 6%, rgba(0,0,0,1) 14%), radial-gradient(360px_220px_at 12% 86%, rgba(0,0,0,0) 0%, rgba(0,0,0,0) 78%, rgba(0,0,0,1) 95%)",
+                    WebkitMaskComposite: "destination-in",
+                    maskComposite: "intersect",
                   }}
                 />
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -117,8 +117,14 @@ export default function Index() {
                   src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F37631ab37615445691181eca7cb49ca7?format=webp&width=1200"
                   alt=""
                   aria-hidden="true"
-                  className="pointer-events-none absolute -bottom-32 left-1/2 -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
+                  className="pointer-events-none absolute -bottom-32 left-[54%] -translate-x-1/2 w-[140vw] max-w-none opacity-95 sm:hidden -z-10"
                   decoding="async"
+                  style={{
+                    WebkitMaskImage:
+                      "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 18%, rgba(0,0,0,1) 100%)",
+                    maskImage:
+                      "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 10%, rgba(0,0,0,1) 18%, rgba(0,0,0,1) 100%)",
+                  }}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Purpose
The user requested to add a background image behind the first picture on the home screen for mobile only, with proper formatting to prevent it from bleeding into the "Clarra Features" or "Our Tech" button sections. Multiple iterations were needed to achieve the correct positioning and layering.

## Code changes
- Updated background image URL to a new asset
- Repositioned image from `bottom-32` to `bottom-0` and adjusted left positioning from `1/2` to `60%`
- Reduced image width from `140vw` to `120vw` and opacity from `95` to `90`
- Added `z-30` class to "Clarra Features" heading to ensure proper layering
- Implemented CSS mask with linear gradient to create a fade effect from transparent to opaque (0% to 18%)
- Maintained mobile-only visibility with `sm:hidden` classTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/quantum-haven)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-quantum-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>quantum-haven</branchName>-->