### PR TITLE
Fix mobile background overlap with "our tech" button

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -6,7 +6,7 @@ export default function Index() {
   return (
     <>
       {/* Hero */}
-      <section className="relative isolate z-10 overflow-hidden bg-transparent pt-10 md:pt-12 pb-0">
+      <section className="relative isolate z-10 overflow-hidden bg-transparent pt-16 md:pt-20 pb-0">
         <div className="container">
           <div className="mx-auto max-w-6xl grid grid-cols-1 sm:grid-cols-12 items-start">
             <div className="sm:col-span-12 sm:col-start-1">


### PR DESCRIPTION
## Purpose
Fix mobile layout issue where the background was overlapping with the "our tech" button, causing visual interference and poor user experience on mobile devices.

## Code changes
- Increased top padding on hero section from `pt-10` to `pt-16` for mobile
- Increased top padding from `md:pt-12` to `md:pt-20` for medium screens and above
- Changes ensure proper spacing between background elements and interactive buttonsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/cosmos-sanctuary)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-cosmos-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>cosmos-sanctuary</branchName>-->