### PR TITLE
Fix mobile underline positioning and text alignment

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -438,11 +438,14 @@ function EmUnderline({
   showOnMobile?: boolean;
 }) {
   return (
-    <span className="relative inline-block px-0.5 align-baseline">
+    <span
+      className={`relative inline-block align-baseline ${showOnMobile ? "px-0 sm:px-0.5 underline sm:no-underline [text-decoration-thickness:3px] [text-underline-offset:0.22em]" : "px-0.5"}`}
+      style={showOnMobile ? ({ textDecorationColor: stroke } as React.CSSProperties) : undefined}
+    >
       <span className="relative z-10">{children}</span>
       <svg
         aria-hidden
-        className={`${showOnMobile ? "" : "hidden sm:block "}pointer-events-none absolute ${showOnMobile ? "left-0 right-0 w-full" : "left-[-1%] right-[-1%] w-[102%]"} h-[0.55em]`}
+        className={`hidden sm:block pointer-events-none absolute left-[-1%] right-[-1%] h-[0.55em] w-[102%]`}
         viewBox="0 0 100 20"
         preserveAspectRatio="none"
         style={{ bottom: `calc(-0.18em * ${offsetScale})` }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -66,11 +66,11 @@ export default function Index() {
       <section className="py-8 pt-16 sm:pt-8">
         <div className="container">
           <div className="grid items-center gap-8 sm:grid-cols-2">
-            <div className="order-2 sm:order-1 sm:translate-x-[10%]">
+            <div className="order-2 sm:order-1 sm:translate-x-[10%] text-center sm:text-left">
               <h3 className="relative z-30 mb-8 text-3xl font-semibold text-foreground/90 mt-[10%] sm:mt-0">
                 Clarra Features
               </h3>
-              <ul className="space-y-4">
+              <ul className="space-y-4 max-w-xl mx-auto sm:mx-0">
                 <li className="flex items-start gap-3">
                   <span className="mt-0.5 inline-flex h-8 w-8 aspect-square shrink-0 items-center justify-center rounded-full bg-[#22c55e] text-white">
                     <IconCheck />

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -442,7 +442,7 @@ function EmUnderline({
       <span className="relative z-10">{children}</span>
       <svg
         aria-hidden
-        className={`${showOnMobile ? "" : "hidden sm:block "}pointer-events-none absolute left-[-1%] right-[-1%] h-[0.55em] w-[102%]`}
+        className={`${showOnMobile ? "" : "hidden sm:block "}pointer-events-none absolute ${showOnMobile ? "left-0 right-0 w-full" : "left-[-1%] right-[-1%] w-[102%]"} h-[0.55em]`}
         viewBox="0 0 100 20"
         preserveAspectRatio="none"
         style={{ bottom: `calc(-0.18em * ${offsetScale})` }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -200,7 +200,7 @@ export default function Index() {
               <span className="text-[#4fb7b3]">the power of AI</span>
               <span> to</span>
               <br />
-              <EmUnderline stroke="#2c3e50" showOnMobile>
+              <EmUnderline stroke="#2c3e50" showOnMobile mobileOffsetEm={0.17}>
                 <span className="text-[#7cc9a2]">TRANSFORM WOMEN’S HEALTH</span>
               </EmUnderline>
               —{" "}
@@ -431,16 +431,26 @@ function EmUnderline({
   offsetScale = 0.8,
   stroke = "hsl(25 97% 66%)",
   showOnMobile = false,
+  mobileOffsetEm = 0.22,
 }: {
   children: React.ReactNode;
   offsetScale?: number;
   stroke?: string;
   showOnMobile?: boolean;
+  mobileOffsetEm?: number;
 }) {
   return (
     <span
-      className={`relative inline-block align-baseline ${showOnMobile ? "px-0 sm:px-0.5 underline sm:no-underline [text-decoration-thickness:3px] [text-underline-offset:0.22em]" : "px-0.5"}`}
-      style={showOnMobile ? ({ textDecorationColor: stroke } as React.CSSProperties) : undefined}
+      className={`relative inline-block align-baseline ${showOnMobile ? "px-0 sm:px-0.5 underline sm:no-underline" : "px-0.5"}`}
+      style={
+        showOnMobile
+          ? ({
+              textDecorationColor: stroke,
+              textDecorationThickness: "3px",
+              textUnderlineOffset: `${mobileOffsetEm}em`,
+            } as React.CSSProperties)
+          : undefined
+      }
     >
       <span className="relative z-10">{children}</span>
       <svg


### PR DESCRIPTION
## Purpose

Fix mobile styling issues with underlined text elements. The user reported that the underline for "health" was too long and should only underline the specific word, "TRANSFORM WOMEN'S HEALTH" should be properly underlined, text was off-centered on mobile, and the underline position needed adjustment.

## Code changes

- **Mobile text alignment**: Added `text-center sm:text-left` to center text on mobile while keeping left alignment on desktop
- **Container width**: Added `max-w-xl mx-auto sm:mx-0` to constrain width and center content on mobile
- **Underline implementation**: Replaced SVG underline with native CSS `text-decoration` on mobile for better control
- **Underline positioning**: Added `mobileOffsetEm` parameter (0.17em) to fine-tune underline offset on mobile
- **Responsive styling**: Updated EmUnderline component to use CSS underlines on mobile and SVG underlines on desktop for precise controlTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/zen-den)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-zen-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>zen-den</branchName>-->