### PR TITLE
Update text colors and mobile layout for hero section

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -34,9 +34,7 @@ export default function Index() {
                     />
                   </svg>
                 </span>{" "}
-                <EmUnderline
-                  stroke="#2c3e50"
-                >
+                <EmUnderline stroke="#2c3e50">
                   <span className="text-[#56d257]">CARE</span>
                 </EmUnderline>{" "}
                 FOR PERIMENOPAUSE, MENOPAUSE & MIDLIFE.

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -39,7 +39,7 @@ export default function Index() {
                   showOnMobile
                   mobileOffsetEm={0.198}
                 >
-                  <span className="text-[#7cc9a2]">CARE</span>
+                  <span className="text-[#56d257]">CARE</span>
                 </EmUnderline>{" "}
                 FOR PERIMENOPAUSE, MENOPAUSE & MIDLIFE.
               </h1>
@@ -187,7 +187,7 @@ export default function Index() {
               Clarra’s mission is to harness{" "}
               <span className="text-[#4fb7b3]">the power of AI</span> to{" "}
               <EmUnderline stroke="#2c3e50">
-                <span className="whitespace-nowrap text-[#7cc9a2]">
+                <span className="whitespace-nowrap text-[#56d257]">
                   transform women’s health
                 </span>
               </EmUnderline>
@@ -205,7 +205,7 @@ export default function Index() {
               <span> to</span>
               <br />
               <EmUnderline stroke="#2c3e50" showOnMobile mobileOffsetEm={0.17}>
-                <span className="text-[#7cc9a2]">TRANSFORM WOMEN’S HEALTH</span>
+                <span className="text-[#56d257]">TRANSFORM WOMEN’S HEALTH</span>
               </EmUnderline>
               —{" "}
               <EmUnderline

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -36,8 +36,6 @@ export default function Index() {
                 </span>{" "}
                 <EmUnderline
                   stroke="#2c3e50"
-                  showOnMobile
-                  mobileOffsetEm={0.198}
                 >
                   <span className="text-[#56d257]">CARE</span>
                 </EmUnderline>{" "}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -69,8 +69,8 @@ export default function Index() {
       {/* Hero split: features left, image right */}
       <section className="py-8 pt-16 sm:pt-8">
         <div className="container">
-          <div className="grid items-center gap-8 sm:grid-cols-2">
-            <div className="order-2 sm:order-1 sm:translate-x-[10%] text-center sm:text-left">
+          <div className="grid items-center gap-8 md:grid-cols-2">
+            <div className="order-2 md:order-1 md:translate-x-[10%] text-center md:text-left">
               <h3 className="relative z-30 mb-8 text-3xl font-semibold text-foreground/90 mt-[10%] sm:mt-0">
                 Clarra Features
               </h3>
@@ -113,8 +113,8 @@ export default function Index() {
                 </li>
               </ul>
             </div>
-            <div className="order-1 sm:order-2 flex justify-center w-full sm:justify-end sm:-translate-x-[30%] relative overflow-visible mx-0">
-              <div className="relative block w-screen sm:w-auto translate-y-0 sm:-translate-y-[6%] mx-[calc(50%-50vw)] sm:mx-0">
+            <div className="order-1 md:order-2 flex justify-center w-full md:justify-end md:-translate-x-[30%] relative overflow-visible mx-0">
+              <div className="relative block w-screen md:w-auto translate-y-0 md:-translate-y-[6%] mx-[calc(50%-50vw)] md:mx-0">
                 <picture>
                   <source
                     media="(max-width: 639px)"
@@ -123,7 +123,7 @@ export default function Index() {
                   <img
                     src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2F9006179a8c0745988cf8fa5fccfa0e0e?format=webp&width=800"
                     alt="Chat with Clarra phone mockup"
-                    className="relative z-10 w-full max-w-none sm:max-w-sm md:max-w-md h-auto drop-shadow-2xl scale-[1.2] sm:scale-[1.7] origin-center mx-auto"
+                    className="relative z-10 w-full max-w-none md:max-w-md h-auto drop-shadow-2xl scale-[1.2] md:scale-[1.7] origin-center mx-auto"
                     loading="eager"
                     decoding="async"
                   />


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses three key improvements to the hero section:
- Change text color for "CARE" and "transform women's health" to a more vibrant green (#56d257)
- Improve mobile layout and text centering to prevent content from being cut off on mobile devices
- Remove underline styling from "CARE" text on mobile to improve readability

## Code changes
- **Color updates**: Changed text color from `#7cc9a2` to `#56d257` for "CARE" and "transform women's health" text spans
- **Mobile layout improvements**: Updated responsive breakpoints from `sm:` to `md:` for better mobile display and centering
- **Underline removal**: Removed `showOnMobile` and `mobileOffsetEm` props from EmUnderline component wrapping "CARE" text to eliminate mobile underline stylingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 29`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/mystic-haven)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>mystic-haven</branchName>-->