### PR TITLE
Fix text cutoff on mobile by adding horizontal padding

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -70,7 +70,7 @@ export default function Index() {
               <h3 className="relative z-30 mb-8 text-3xl font-semibold text-foreground/90 mt-[10%] sm:mt-0">
                 Clarra Features
               </h3>
-              <ul className="space-y-4 max-w-xl mx-auto sm:mx-0">
+              <ul className="space-y-4 max-w-xl mx-auto sm:mx-0 px-4 sm:px-0">
                 <li className="flex items-start gap-3">
                   <span className="mt-0.5 inline-flex h-8 w-8 aspect-square shrink-0 items-center justify-center rounded-full bg-[#22c55e] text-white">
                     <IconCheck />


### PR DESCRIPTION
## Purpose
Fix text being cut off on the right side of the screen on mobile devices by adding appropriate horizontal padding that only applies to mobile viewports.

## Code changes
- Added `px-4 sm:px-0` classes to the features list container in `client/pages/Index.tsx`
- This adds 16px horizontal padding on mobile devices while maintaining no padding on larger screens
- Prevents text content from being clipped at the screen edges on mobileTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/nova-field)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-nova-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>nova-field</branchName>-->