### PR TITLE
Reduce hero text size on mobile by 25%

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -87,11 +87,11 @@ export default function Index() {
                 behind what you're experiencing.
               </p>
             </div>
-            <div className="relative flex justify-center lg:justify-center">
+            <div className="relative flex justify-center lg:justify-end">
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Ffd5ad7ebdaed4699adc9a9bc4bae7a68?format=webp&width=2000"
                 alt="Clarra insights"
-                className="w-full max-w-[460px] object-contain scale-[1.925] mix-blend-multiply"
+                className="w-full max-w-[460px] object-contain -translate-x-[82%] scale-[1.925] mix-blend-multiply"
               />
             </div>
           </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -87,11 +87,11 @@ export default function Index() {
                 behind what you're experiencing.
               </p>
             </div>
-            <div className="relative flex justify-center lg:justify-end">
+            <div className="relative flex justify-center lg:justify-center">
               <img
                 src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Ffd5ad7ebdaed4699adc9a9bc4bae7a68?format=webp&width=2000"
                 alt="Clarra insights"
-                className="w-full max-w-[460px] object-contain -translate-x-[82%] scale-[1.925] mix-blend-multiply"
+                className="w-full max-w-[460px] object-contain scale-[1.925] mix-blend-multiply"
               />
             </div>
           </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -18,7 +18,7 @@ export default function Index() {
         <div className="absolute inset-0 w-full h-full overflow-visible">
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fad61ae606c6b402e9e3942e4f23fbe55?format=webp&width=2000"
-            className="w-full h-full object-cover brightness-[1.03] saturate-[1.15] contrast-[1.18] scale-90 sm:scale-100"
+            className="w-full h-full object-cover brightness-[1.03] saturate-[1.15] contrast-[1.18] scale-90 -translate-y-[20%] sm:scale-100 sm:translate-y-0"
             style={{
               objectPosition: "calc(50% + 25px) 46px",
             }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -18,7 +18,7 @@ export default function Index() {
         <div className="absolute inset-0 w-full h-full overflow-visible">
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2F553c8106b9f84f1a91a6549e0008f0fd%2Fad61ae606c6b402e9e3942e4f23fbe55?format=webp&width=2000"
-            className="w-full h-full object-cover brightness-[1.03] saturate-[1.15] contrast-[1.18] scale-90 -translate-y-[20%] sm:scale-100 sm:translate-y-0"
+            className="w-full h-full object-cover brightness-[1.03] saturate-[1.15] contrast-[1.18] scale-90 sm:scale-100"
             style={{
               objectPosition: "calc(50% + 25px) 46px",
             }}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -46,13 +46,13 @@ export default function Index() {
           <div className="grid grid-cols-1 lg:grid-cols-[55%_45%] gap-12 lg:gap-20 items-center">
             {/* Left Column - Text */}
             <div className="flex flex-col justify-center">
-              <h1 className="font-display text-[44px] sm:text-[67px] md:text-[81px] font-extrabold text-[hsl(210_29%_16%)] leading-[1.0] sm:leading-[1.05] mb-6 drop-shadow-sm">
-                <span className="font-serif italic font-light block mb-2 leading-[1.05] sm:leading-[1.1] text-[39px] sm:text-[60px] md:text-[73px]">
+              <h1 className="font-display text-[33px] sm:text-[67px] md:text-[81px] font-extrabold text-[hsl(210_29%_16%)] leading-[1.0] sm:leading-[1.05] mb-6 drop-shadow-sm">
+                <span className="font-serif italic font-light block mb-2 leading-[1.05] sm:leading-[1.1] text-[29px] sm:text-[60px] md:text-[73px]">
                   Make sense of
                 </span>
                 perimenopause
               </h1>
-              <p className="text-lg sm:text-xl text-foreground/90 font-medium leading-relaxed mb-8 max-w-[520px] drop-shadow-sm">
+              <p className="text-sm sm:text-xl text-foreground/90 font-medium leading-relaxed mb-8 max-w-[520px] drop-shadow-sm">
                 Clarra interprets your symptoms, hormones, sleep, mood, and
                 cycles — giving you a clear picture of what’s changing and what
                 to do next.


### PR DESCRIPTION
## Purpose
The user requested to reduce the size of the hero section text on mobile devices only. Specifically, they wanted to decrease the heading "Make sense of perimenopause" and its accompanying description text by 25% to improve mobile readability and layout.

## Code changes
- Reduced the main heading (`h1`) font size on mobile from `44px` to `33px` (25% reduction)
- Reduced the italic "Make sense of" span font size on mobile from `39px` to `29px` (25% reduction)
- Reduced the description paragraph (`p`) font size on mobile from `text-lg` (18px) to `text-sm` (14px) (approximately 22% reduction)
- Desktop and tablet breakpoints (`sm:` and `md:`) remain unchanged to preserve the original design on larger screens

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/74ce017cad5440f7b061f3a513361e6c/echo-hub)

👀 [Preview Link](https://74ce017cad5440f7b061f3a513361e6c-echo-hub.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 64`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74ce017cad5440f7b061f3a513361e6c</projectId>-->
<!--<branchName>echo-hub</branchName>-->